### PR TITLE
prevent php warnings regarding undefined constants

### DIFF
--- a/app/views/app/index.php
+++ b/app/views/app/index.php
@@ -21,7 +21,7 @@ var cliqr = {
 <div id="cliqr-container"></div>
 <?= $this->render_partial('_noscript') ?>
 
-<? if (constant('WDS_ACTIVATED')) { ?>
+<? if (defined('WDS_ACTIVATED') && constant('WDS_ACTIVATED')) { ?>
     <link charset="utf-8" href="http://localhost:8081/bundle.css" rel="stylesheet" media="screen, print">
     <script charset="utf-8" src="http://localhost:8081/studip.js"></script>
 <? } else { ?>

--- a/app/views/polls/index.php
+++ b/app/views/polls/index.php
@@ -48,7 +48,7 @@
 
         <script src="<?= \Assets::javascript_path('mathjax/MathJax.js?config=TeX-AMS_HTML,default') ?>"></script>
 
-        <? if (constant('WDS_ACTIVATED')) { ?>
+        <? if (defined('WDS_ACTIVATED') && constant('WDS_ACTIVATED')) { ?>
             <link charset="utf-8" href="http://localhost:8081/bundle.css" rel="stylesheet" media="screen, print">
             <script charset="utf-8" src="http://localhost:8081/polls.js"></script>
         <? } else { ?>


### PR DESCRIPTION
Our error log was slowly filled with entries like this:

```
PHP Warning:  constant(): Couldn't find constant WDS_ACTIVATED in /var/www/studip-3.5/public/plugins_packages/elan-ev/CliqrPlugin/app/views/polls/index.php on line 51
```

These changes prevent that.